### PR TITLE
Fix density APK split issue

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="fr.tvbarthel.experiment.splitdensitybug">
+
+    <!--
+        BUG: DENSITY APK SPLITS
+
+        There is an issue with apk splitting resulting in addition
+        of three permissions.
+
+        Bug Tracker
+        https://code.google.com/p/android/issues/detail?id=197928
+
+        For the moment, the solution we found is to remove those permissions manually
+        using node marker.
+    -->
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        tools:node="remove" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        tools:node="remove" />
+    <uses-permission
+        android:name="android.permission.READ_PHONE_STATE"
+        tools:node="remove" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
Remove the three extra permission manually.

*temporary solution - do not merge*